### PR TITLE
No way to cause a restart from the app, but logout is good enough

### DIFF
--- a/disabled-wifi/utils.swift
+++ b/disabled-wifi/utils.swift
@@ -24,6 +24,11 @@ func runBashCommand(command: String) {
     }
 }
 
+// Runs command which logsout current user
+func logout() {
+    runBashCommand(command: "launchctl bootout gui/$(id -u $(whoami))")
+}
+
 func formatTimeLeft(tillDate: Date) -> String {
     let formatter = DateComponentsFormatter()
     formatter.allowedUnits = [.minute, .hour, .second]


### PR DESCRIPTION
Breakthrough! There is no way to run a `reboot` from the sandboxed app, there is no even a way to ask for more privileges. But `logout` is available as is and works as good :tada: 